### PR TITLE
Add config option to disable update check

### DIFF
--- a/configSchema.json
+++ b/configSchema.json
@@ -36,6 +36,9 @@
     },
     "uninstallMode": {
       "type": "boolean"
+    },
+    "checkUpdate": {
+      "type": "boolean"
     }
   },
   "required": [
@@ -43,6 +46,7 @@
     "disablePricePenalty",
     "villagerBlacklist",
     "allowTravellingMerchants",
-    "uninstallMode"
+    "uninstallMode",
+    "checkUpdate"
   ]
 }

--- a/src/main/java/me/spartacus04/instantrestock/InstantRestock.kt
+++ b/src/main/java/me/spartacus04/instantrestock/InstantRestock.kt
@@ -29,11 +29,13 @@ class InstantRestock : JavaPlugin(), Listener {
         if(CONFIG.allowMetrics)
             Metrics(this, 16589)
 
-        Updater(this).getVersion {
-            if(it != description.version) {
-                Bukkit.getConsoleSender().sendMessage(
-                    "[§aInfiniteVillagerTrading§f] A new update is available!"
-                )
+        if(CONFIG.checkUpdate) {
+            Updater(this).getVersion {
+                if(it != description.version) {
+                    Bukkit.getConsoleSender().sendMessage(
+                        "[§aInfiniteVillagerTrading§f] A new update is available!"
+                    )
+                }
             }
         }
     }

--- a/src/main/java/me/spartacus04/instantrestock/Settings.kt
+++ b/src/main/java/me/spartacus04/instantrestock/Settings.kt
@@ -11,6 +11,7 @@ import org.bukkit.plugin.java.JavaPlugin
  * @property disablePricePenalty Indicates if the price penalty is disabled.
  * @property uninstallMode Indicates if the uninstall mode is enabled.
  * @property allowTravellingMerchants Indicates if travelling merchants are allowed.
+ * @property checkUpdate Indicates if checking for updates is allowed.
  * @property allowMetrics Indicates if metrics are allowed.
  */
 data class Settings(
@@ -19,6 +20,7 @@ data class Settings(
     var disablePricePenalty: Boolean = false,
     var uninstallMode: Boolean = false,
     var allowTravellingMerchants: Boolean = true,
+    var checkUpdate: Boolean = true,
     var allowMetrics: Boolean = true
 )
 

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -30,6 +30,9 @@
   //Restores the villager trades to their original state.
   "uninstallMode": false,
 
+  //Allows the plugin to check for updates
+  "checkUpdate": true,
+
   // Allow/Disallow plugin metrics (no personal data is going to be collected)
   "allow-metrics": true
 }


### PR DESCRIPTION
#### Why
GitHub has a 60 requests/hour rate limit on anonymous requests. When using many plugins, many with update checkers requesting GitHub's API, this limit is quickly reached (especially with many server instances on a velocity network...). I have an update script that caches latest versions and dates (so it isn't limited by the ratelimit because [conditional queries](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate)), but this plugin decreases that limit by one per server start.

#### What
This pull requests adds a simple `checkUpdate` config option (defaults to true) and a simple condition check in the plugin initialization when the plugin checks for update.